### PR TITLE
Make filtering cheaper - do not create wrapper object when we are not…

### DIFF
--- a/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
+++ b/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
@@ -45,8 +45,10 @@ static const NSUInteger kFBRetainCycleDetectorDefaultStackDepth = 10;
 
 - (void)addCandidate:(id)candidate
 {
-  FBObjectiveCGraphElement *graphElement = FBWrapObjectGraphElement(candidate, _configuration);
-  [_candidates addObject:graphElement];
+  FBObjectiveCGraphElement *graphElement = FBWrapObjectGraphElement(nil, candidate, _configuration);
+  if (graphElement) {
+    [_candidates addObject:graphElement];
+  }
 }
 
 - (NSSet<NSArray<FBObjectiveCGraphElement *> *> *)findRetainCycles

--- a/FBRetainCycleDetector/FBRetainCycleUtils.h
+++ b/FBRetainCycleDetector/FBRetainCycleUtils.h
@@ -20,10 +20,12 @@ extern "C" {
  Wrapper functions, for given object they will categorize it and create proper Graph Element subclass instance
  for it.
  */
-FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(id object,
+FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(FBObjectiveCGraphElement *sourceElement,
+                                                              id object,
                                                               FBObjectGraphConfiguration *configuration,
                                                               NSArray<NSString *> *namePath);
-FBObjectiveCGraphElement *FBWrapObjectGraphElement(id object,
+FBObjectiveCGraphElement *FBWrapObjectGraphElement(FBObjectiveCGraphElement *sourceElement,
+                                                   id object,
                                                    FBObjectGraphConfiguration *configuration);
 
 #ifdef __cplusplus

--- a/FBRetainCycleDetector/FBRetainCycleUtils.h
+++ b/FBRetainCycleDetector/FBRetainCycleUtils.h
@@ -20,13 +20,13 @@ extern "C" {
  Wrapper functions, for given object they will categorize it and create proper Graph Element subclass instance
  for it.
  */
-FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(FBObjectiveCGraphElement *sourceElement,
-                                                              id object,
-                                                              FBObjectGraphConfiguration *configuration,
-                                                              NSArray<NSString *> *namePath);
-FBObjectiveCGraphElement *FBWrapObjectGraphElement(FBObjectiveCGraphElement *sourceElement,
-                                                   id object,
-                                                   FBObjectGraphConfiguration *configuration);
+FBObjectiveCGraphElement *_Nullable FBWrapObjectGraphElementWithContext(FBObjectiveCGraphElement *_Nullable sourceElement,
+                                                                        id _Nullable object,
+                                                                        FBObjectGraphConfiguration *_Nullable configuration,
+                                                                        NSArray<NSString *> *_Nullable namePath);
+FBObjectiveCGraphElement *_Nullable FBWrapObjectGraphElement(FBObjectiveCGraphElement *_Nullable sourceElement,
+                                                             id _Nullable object,
+                                                             FBObjectGraphConfiguration *_Nullable configuration);
 
 #ifdef __cplusplus
 }

--- a/FBRetainCycleDetector/FBRetainCycleUtils.m
+++ b/FBRetainCycleDetector/FBRetainCycleUtils.m
@@ -36,7 +36,7 @@ FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(FBObjectiveCGraphE
                                                               id object,
                                                               FBObjectGraphConfiguration *configuration,
                                                               NSArray<NSString *> *namePath) {
-  if (_ShouldBreakGraphEdge(configuration, sourceElement, [namePath objectAtIndex:0], object_getClass(object))) {
+  if (_ShouldBreakGraphEdge(configuration, sourceElement, [namePath firstObject], object_getClass(object))) {
     return nil;
   }
   

--- a/FBRetainCycleDetector/FBRetainCycleUtils.m
+++ b/FBRetainCycleDetector/FBRetainCycleUtils.m
@@ -19,9 +19,27 @@
 #import "FBObjectiveCObject.h"
 #import "FBObjectGraphConfiguration.h"
 
-FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(id object,
+static BOOL _ShouldBreakGraphEdge(FBObjectGraphConfiguration *configuration,
+                                  FBObjectiveCGraphElement *fromObject,
+                                  NSString *byIvar,
+                                  Class toObjectOfClass) {
+  for (FBGraphEdgeFilterBlock filterBlock in configuration.filterBlocks) {
+    if (filterBlock(fromObject, byIvar, toObjectOfClass) == FBGraphEdgeInvalid) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
+FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(FBObjectiveCGraphElement *sourceElement,
+                                                              id object,
                                                               FBObjectGraphConfiguration *configuration,
                                                               NSArray<NSString *> *namePath) {
+  if (_ShouldBreakGraphEdge(configuration, sourceElement, [namePath objectAtIndex:0], object_getClass(object))) {
+    return nil;
+  }
+  
   if (FBObjectIsBlock((__bridge void *)object)) {
     return [[FBObjectiveCBlock alloc] initWithObject:object
                                       configuration:configuration
@@ -40,7 +58,8 @@ FBObjectiveCGraphElement *FBWrapObjectGraphElementWithContext(id object,
   }
 }
 
-FBObjectiveCGraphElement *FBWrapObjectGraphElement(id object,
+FBObjectiveCGraphElement *FBWrapObjectGraphElement(FBObjectiveCGraphElement *sourceElement,
+                                                   id object,
                                                    FBObjectGraphConfiguration *configuration) {
-  return FBWrapObjectGraphElementWithContext(object, configuration, nil);
+  return FBWrapObjectGraphElementWithContext(sourceElement, object, configuration, nil);
 }

--- a/FBRetainCycleDetector/Filtering/FBStandardGraphEdgeFilters.mm
+++ b/FBRetainCycleDetector/Filtering/FBStandardGraphEdgeFilters.mm
@@ -23,12 +23,12 @@ FBGraphEdgeFilterBlock FBFilterBlockWithObjectIvarRelation(Class aCls, NSString 
 FBGraphEdgeFilterBlock FBFilterBlockWithObjectToManyIvarsRelation(Class aCls,
                                                                   NSSet<NSString *> *ivarNames) {
   return ^(FBObjectiveCGraphElement *fromObject,
-           FBObjectiveCGraphElement *toObject){
+           NSString *byIvar,
+           Class toObjectOfClass){
     if (aCls &&
         [[fromObject objectClass] isSubclassOfClass:aCls]) {
       // If graph element holds metadata about an ivar, it will be held in the name path, as early as possible
-      NSString *ivarName = [[toObject namePath] objectAtIndex:0];
-      if ([ivarNames containsObject:ivarName]) {
+      if ([ivarNames containsObject:byIvar]) {
         return FBGraphEdgeInvalid;
       }
     }
@@ -38,10 +38,11 @@ FBGraphEdgeFilterBlock FBFilterBlockWithObjectToManyIvarsRelation(Class aCls,
 
 FBGraphEdgeFilterBlock FBFilterBlockWithObjectIvarObjectRelation(Class fromClass, NSString *ivarName, Class toClass) {
   return ^(FBObjectiveCGraphElement *fromObject,
-           FBObjectiveCGraphElement *toObject) {
+           NSString *byIvar,
+           Class toObjectOfClass) {
     if (toClass &&
-        [[toObject objectClass] isSubclassOfClass:toClass]) {
-      return FBFilterBlockWithObjectIvarRelation(fromClass, ivarName)(fromObject, toObject);
+        [toObjectOfClass isSubclassOfClass:toClass]) {
+      return FBFilterBlockWithObjectIvarRelation(fromClass, ivarName)(fromObject, byIvar, toObjectOfClass);
     }
     return FBGraphEdgeValid;
   };

--- a/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.h
+++ b/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.h
@@ -24,7 +24,8 @@ typedef NS_ENUM(NSUInteger, FBGraphEdgeType) {
  @see FBGetStandardGraphEdgeFilters()
  */
 typedef FBGraphEdgeType (^FBGraphEdgeFilterBlock)(FBObjectiveCGraphElement *_Nullable fromObject,
-                                                  FBObjectiveCGraphElement *_Nullable toObject);
+                                                  NSString *_Nullable byIvar,
+                                                  Class _Nullable toObjectOfClass);
 
 /**
  FBObjectGraphConfiguration represents a configuration for object graph walking.

--- a/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
@@ -19,12 +19,6 @@
 
 - (NSSet *)allRetainedObjects
 {
-  NSArray *unfiltered = [self _unfilteredRetainedObjects];
-  return [self filterObjects:unfiltered];
-}
-
-- (NSArray *)_unfilteredRetainedObjects
-{
   NSMutableArray *results = [[[super allRetainedObjects] allObjects] mutableCopy];
 
   // Grab a strong reference to the object, otherwise it can crash while doing
@@ -35,10 +29,13 @@
   NSArray *allRetainedReferences = FBGetBlockStrongReferences(blockObjectReference);
 
   for (id object in allRetainedReferences) {
-    [results addObject:FBWrapObjectGraphElement(object, self.configuration)];
+    FBObjectiveCGraphElement *element = FBWrapObjectGraphElement(self, object, self.configuration);
+    if (element) {
+      [results addObject:element];
+    }
   }
 
-  return results;
+  return [NSSet setWithArray:results];
 }
 
 @end

--- a/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.h
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.h
@@ -49,14 +49,6 @@
 - (nullable NSSet *)allRetainedObjects;
 
 /**
- Filter objects using filter provider.
- 
- @param objects Objects to be filtered that are references from this object
- @return NSSet of filtered objects
- */
-- (nonnull NSSet *)filterObjects:(nullable NSArray *)objects;
-
-/**
  @return address of the object represented by this element
  */
 - (size_t)objectAddress;

--- a/FBRetainCycleDetector/Graph/FBObjectiveCObject.m
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCObject.m
@@ -20,12 +20,6 @@
 
 - (NSSet *)allRetainedObjects
 {
-  NSArray *unfiltered = [self _unfilteredRetainedObjects];
-  return [self filterObjects:unfiltered];
-}
-
-- (NSArray *)_unfilteredRetainedObjects
-{
   Class aCls = object_getClass(self.object);
   if (!self.object || !aCls) {
     return nil;
@@ -40,9 +34,13 @@
 
     if (referencedObject) {
       NSArray<NSString *> *namePath = [ref namePath];
-      [retainedObjects addObject:FBWrapObjectGraphElementWithContext(referencedObject,
-                                                                     self.configuration,
-                                                                     namePath)];
+      FBObjectiveCGraphElement *element = FBWrapObjectGraphElementWithContext(self,
+                                                                              referencedObject,
+                                                                              self.configuration,
+                                                                              namePath);
+      if (element) {
+        [retainedObjects addObject:element];
+      }
     }
   }
 
@@ -52,7 +50,7 @@
      will hold only Objective-C objects. We are not able to check in runtime what callbacks it uses to
      retain/release (if any) and we could easily crash here.
      */
-    return retainedObjects;
+    return [NSSet setWithArray:retainedObjects];
   }
 
   if (class_isMetaClass(aCls)) {
@@ -82,11 +80,18 @@
       @try {
         for (id subobject in self.object) {
           if (retainsKeys) {
-            [temporaryRetainedObjects addObject:FBWrapObjectGraphElement(subobject, self.configuration)];
+            FBObjectiveCGraphElement *element = FBWrapObjectGraphElement(self, subobject, self.configuration);
+            if (element) {
+              [temporaryRetainedObjects addObject:element];
+            }
           }
           if (isKeyValued && retainsValues) {
-            [temporaryRetainedObjects addObject:FBWrapObjectGraphElement([self.object objectForKey:subobject],
-                                                                         self.configuration)];
+            FBObjectiveCGraphElement *element = FBWrapObjectGraphElement(self,
+                                                                         [self.object objectForKey:subobject],
+                                                                         self.configuration);
+            if (element) {
+              [temporaryRetainedObjects addObject:element];
+            }
           }
         }
       }
@@ -101,7 +106,7 @@
     }
   }
 
-  return retainedObjects;
+  return [NSSet setWithArray:retainedObjects];
 }
 
 - (BOOL)_objectRetainsEnumerableValues

--- a/FBRetainCycleDetector/Graph/Specialization/FBObjectiveCNSCFTimer.mm
+++ b/FBRetainCycleDetector/Graph/Specialization/FBObjectiveCNSCFTimer.mm
@@ -43,10 +43,16 @@ typedef struct {
   if (context.info && context.retain) {
     _FBNSCFTimerInfoStruct infoStruct = *(_FBNSCFTimerInfoStruct *)(context.info);
     if (infoStruct.target) {
-      [retained addObject:FBWrapObjectGraphElementWithContext(infoStruct.target, self.configuration, @[@"target"])];
+      FBObjectiveCGraphElement *element = FBWrapObjectGraphElementWithContext(self, infoStruct.target, self.configuration, @[@"target"]);
+      if (element) {
+        [retained addObject:element];
+      }
     }
     if (infoStruct.userInfo) {
-      [retained addObject:FBWrapObjectGraphElementWithContext(infoStruct.userInfo, self.configuration, @[@"userInfo"])];
+      FBObjectiveCGraphElement *element = FBWrapObjectGraphElementWithContext(self, infoStruct.userInfo, self.configuration, @[@"userInfo"]);
+      if (element) {
+        [retained addObject:element];
+      }
     }
   }
 


### PR DESCRIPTION
… going to use given node. Right now we just simply create wrapped object for every possible case, but this tends to be very ineffective when we are for example creating wrapper objects around NSStrings