### PR TITLE
Add support for unnamed structs

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/Parser/FBStructEncodingParser.mm
+++ b/FBRetainCycleDetector/Layout/Classes/Parser/FBStructEncodingParser.mm
@@ -105,10 +105,14 @@ namespace FB { namespace RetainCycleDetector { namespace Parser {
         const auto locBefore = scanner.index;
         auto parseResult = _ParseStructEncodingWithScanner(scanner, debugStruct);
         
-        const auto nameFromBefore = std::dynamic_pointer_cast<Unresolved>(types.back());
-        NSCAssert(nameFromBefore, @"There should always be a name from before if we hit a struct; debug_struct: %@", debugStruct);
-        types.pop_back();
-        std::shared_ptr<Struct> type = std::make_shared<Struct>(nameFromBefore->value,
+        std::shared_ptr<Unresolved> valueFromBefore;
+        if (!types.empty()) {
+          valueFromBefore = std::dynamic_pointer_cast<Unresolved>(types.back());
+          types.pop_back();
+        }
+        const auto extractedNameFromBefore = valueFromBefore ? valueFromBefore->value
+                                                             : "";
+        std::shared_ptr<Struct> type = std::make_shared<Struct>(extractedNameFromBefore,
                                                                 scanner.string.substr(locBefore, (scanner.index - locBefore)),
                                                                 parseResult.typeName,
                                                                 parseResult.containedTypes);

--- a/FBRetainCycleDetectorTests/FBStructEncodingParserTests.mm
+++ b/FBRetainCycleDetectorTests/FBStructEncodingParserTests.mm
@@ -45,16 +45,22 @@ struct _RCDTestStructWithUnnamedBitfield {
   unsigned : 4;
 };
 
+struct _RCDTestStructWithUnnamedStruct {
+  struct {
+    bool value;
+  };
+};
+
 @interface _RCDParserTestClass : NSObject
 @property (nonatomic, assign) _RCDTestStructWithPrimitive structWithPrimitive;
 @property (nonatomic, assign) _RCDTestStructWithObject structWithObject;
 @property (nonatomic, assign) _RCDTestStructWithObjectPrimitiveMixin structWithObjectPrimitiveMixin;
 @property (nonatomic, assign) _RCDTestStructWithNestedStruct structWithNestedStruct;
 @property (nonatomic, assign) _RCDTestStructWithUnnamedBitfield structWithUnnamedBitfield;
+@property (nonatomic, assign) _RCDTestStructWithUnnamedStruct structWithUnnamedStruct;
 @end
 @implementation _RCDParserTestClass
 @end
-
 
 
 @implementation FBStructEncodingTests
@@ -182,6 +188,25 @@ struct _RCDTestStructWithUnnamedBitfield {
     "_RCDTestStructWithObjectPrimitiveMixin",
   };
   XCTAssertEqual(innerStruct->typesContainedInStruct[1]->typePath, expectedNamePath);
+}
+
+- (void)testThatParserWillParseStructWithUnnamedStruct
+{
+  std::string encoding = [self _getIvarEncodingByName:@"_structWithUnnamedStruct"
+                                             forClass:[_RCDParserTestClass class]];
+  XCTAssertTrue(encoding.length() > 0);
+  FB::RetainCycleDetector::Parser::Struct parsedStruct =
+  FB::RetainCycleDetector::Parser::parseStructEncoding(encoding);
+  
+  XCTAssertEqual(parsedStruct.typesContainedInStruct.size(), 1);
+  
+  std::shared_ptr<FB::RetainCycleDetector::Parser::Struct> innerStruct =
+  std::dynamic_pointer_cast<FB::RetainCycleDetector::Parser::Struct>(parsedStruct.typesContainedInStruct[0]);
+  XCTAssertTrue(innerStruct);
+  
+  XCTAssertEqual(innerStruct->typesContainedInStruct.size(), 1);
+  XCTAssertEqual(innerStruct->typesContainedInStruct[0]->name, "value");
+  XCTAssertEqual(innerStruct->typesContainedInStruct[0]->typeEncoding, "B");
 }
 
 @end


### PR DESCRIPTION
If we currently have an unnamed struct, it will happily just fail because we assert against it.