### PR TITLE
Remove incorrect type cast

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
+++ b/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
@@ -199,7 +199,7 @@ NSArray<id<FBObjectReference>> *FBGetObjectStrongReferences(id obj,
     if (!ivars) {
       ivars = FBGetStrongReferencesForClass(currentClass);
       if (layoutCache && currentClass) {
-        layoutCache[(id<NSCopying>)currentClass] = ivars;
+        layoutCache[currentClass] = ivars;
       }
     }
     [array addObjectsFromArray:ivars];


### PR DESCRIPTION
This change addresses following compiler warning:
VendorLib/FBRetainCycleDetector/src/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm:202:21: error: incompatible pointer types sending 'id<NSCopying>' to parameter of type 'Class<NSCopying> _Nonnull' [-Werror,-Wincompatible-pointer-types]
layoutCache[(id<NSCopying>)currentClass] = ivars;