### PR TITLE
guard addObjectsFromArray receive nil param

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
+++ b/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
@@ -167,7 +167,7 @@ static NSArray<id<FBObjectReference>> *FBGetStrongReferencesForClass(Class aCls)
   const uint8_t *fullLayout = class_getIvarLayout(aCls);
 
   if (!fullLayout) {
-    return nil;
+    return @[];
   }
 
   NSUInteger minimumIndex = FBGetMinimumIvarIndex(aCls);


### PR DESCRIPTION
https://github.com/facebook/FBRetainCycleDetector/blob/master/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm#L205

- addObjectsFromArray:  receive an nil param, we would guard at FBGetStrongReferencesForClass()

![image](https://cloud.githubusercontent.com/assets/13046550/22682668/ea2885fc-ed4e-11e6-8b9f-0599e6293136.png)
