### PR TITLE
Add block code pointer to the cycle to allow symbolication

### DIFF
--- a/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.h
+++ b/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.h
@@ -57,14 +57,28 @@ typedef FBObjectiveCGraphElement *_Nullable(^FBObjectiveCGraphElementTransformer
 @property (nonatomic, readonly) BOOL shouldInspectTimers;
 
 /**
+ Decides if block objects should include their invocation address (the code part of the block) in the report.
+ If set to YES, then it will change from: `MallocBlock` to `<<MallocBlock:0xADDR>>`.
+ You can then symbolicate the address to retrieve a symbol name which will look like:
+ `__FOO_block_invoke` where FOO is replaced by the function creating the block.
+ This will allow easier understanding of the code involved in the cycle when blocks are involved.
+ */
+@property (nonatomic, readonly) BOOL shouldIncludeBlockAddress;
+
+/**
  Will cache layout
  */
 @property (nonatomic, readonly, nullable) NSMutableDictionary<Class, NSArray<id<FBObjectReference>> *> *layoutCache;
 @property (nonatomic, readonly) BOOL shouldCacheLayouts;
 
 - (nonnull instancetype)initWithFilterBlocks:(nonnull NSArray<FBGraphEdgeFilterBlock> *)filterBlocks
-                         shouldInspectTimers:(BOOL)shouldInspectTimers 
-                            transformerBlock:(nullable FBObjectiveCGraphElementTransformerBlock)transformerBlock NS_DESIGNATED_INITIALIZER;
+                         shouldInspectTimers:(BOOL)shouldInspectTimers
+                         transformerBlock:(nullable FBObjectiveCGraphElementTransformerBlock)transformerBlock
+                         shouldIncludeBlockAddress:(BOOL)shouldIncludeBlockAddress NS_DESIGNATED_INITIALIZER;
+
+- (nonnull instancetype)initWithFilterBlocks:(nonnull NSArray<FBGraphEdgeFilterBlock> *)filterBlocks
+                         shouldInspectTimers:(BOOL)shouldInspectTimers
+                         transformerBlock:(nullable FBObjectiveCGraphElementTransformerBlock)transformerBlock;
 
 - (nonnull instancetype)initWithFilterBlocks:(nonnull NSArray<FBGraphEdgeFilterBlock> *)filterBlocks
                          shouldInspectTimers:(BOOL)shouldInspectTimers;

--- a/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.m
+++ b/FBRetainCycleDetector/Graph/FBObjectGraphConfiguration.m
@@ -14,15 +14,27 @@
 - (instancetype)initWithFilterBlocks:(NSArray<FBGraphEdgeFilterBlock> *)filterBlocks
                  shouldInspectTimers:(BOOL)shouldInspectTimers
                     transformerBlock:(nullable FBObjectiveCGraphElementTransformerBlock)transformerBlock
+           shouldIncludeBlockAddress:(BOOL)shouldIncludeBlockAddress
 {
   if (self = [super init]) {
     _filterBlocks = [filterBlocks copy];
     _shouldInspectTimers = shouldInspectTimers;
+    _shouldIncludeBlockAddress = shouldIncludeBlockAddress;
     _transformerBlock = [transformerBlock copy];
     _layoutCache = [NSMutableDictionary new];
   }
-  
+
   return self;
+}
+
+- (instancetype)initWithFilterBlocks:(NSArray<FBGraphEdgeFilterBlock> *)filterBlocks
+                 shouldInspectTimers:(BOOL)shouldInspectTimers
+                    transformerBlock:(nullable FBObjectiveCGraphElementTransformerBlock)transformerBlock
+{
+  return [self initWithFilterBlocks:filterBlocks
+                shouldInspectTimers:shouldInspectTimers
+                   transformerBlock:transformerBlock
+          shouldIncludeBlockAddress:NO];
 }
 
 - (instancetype)initWithFilterBlocks:(NSArray<FBGraphEdgeFilterBlock> *)filterBlocks

--- a/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
@@ -12,8 +12,18 @@
 #import <objc/runtime.h>
 
 #import "FBBlockStrongLayout.h"
+#import "FBBlockStrongRelationDetector.h"
+#import "FBObjectGraphConfiguration.h"
 #import "FBObjectiveCObject.h"
 #import "FBRetainCycleUtils.h"
+
+struct __attribute__((packed)) BlockLiteral {
+  void *isa;
+  int flags;
+  int reserved;
+  void *invoke;
+  void *descriptor;
+};
 
 @implementation FBObjectiveCBlock
 
@@ -36,6 +46,55 @@
   }
 
   return [NSSet setWithArray:results];
+}
+
+/**
+ * We want to add more information to blocks because they show up
+ * in reports as MallocBlock and StackBlock which is not very informative.
+ *
+ * A block object is composed of:
+ * - code: what should be executed, it's stored in the .TEXT section ;
+ * - data: the variables that have been captured ;
+ * - metadata: notably the function signature.
+ *
+ * We extract the address of the code, which can then be converted to a
+ * human readable name given the debug symbol file.
+ *
+ * The symbol name contains the name of the function which allocated
+ * the block, making is easier to track the piece of code participating
+ * in the cycle. The symbolication must be done outside of this code
+ * since it will require access to the debug symbols, not present at
+ * runtime.
+ *
+ * Format: <<CLASSNAME:0xADDR>>
+ */
+- (NSString *)classNameOrNull
+{
+  NSString *className = NSStringFromClass([self objectClass]);
+  if (!className) {
+    className = @"Null";
+  }
+
+  if (!self.configuration.shouldIncludeBlockAddress) {
+    return className;
+  }
+
+  // Find the reference of the block object.
+  __attribute__((objc_precise_lifetime)) id anObject = self.object;
+  if ([anObject isKindOfClass:[FBBlockStrongRelationDetector class]]) {
+    FBBlockStrongRelationDetector *blockObject = anObject;
+    anObject = [blockObject forwarding];
+  }
+  void *blockObjectReference = (__bridge void *)anObject;
+  if (!blockObjectReference) {
+    return className;
+  }
+
+  // Extract the invocated block of code from the structure.
+  const struct BlockLiteral *block = (struct BlockLiteral*) blockObjectReference;
+  const void *blockCodePtr = block->invoke;
+
+  return [NSString stringWithFormat:@"<<%@:0x%llx>>", className, (unsigned long long)blockCodePtr];
 }
 
 @end

--- a/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.mm
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.mm
@@ -102,9 +102,9 @@
 {
   if (_namePath) {
     NSString *namePathStringified = [_namePath componentsJoinedByString:@" -> "];
-    return [NSString stringWithFormat:@"-> %@ -> %@ ", namePathStringified, object_getClass(_object)];
+    return [NSString stringWithFormat:@"-> %@ -> %@ ", namePathStringified, [self classNameOrNull]];
   }
-  return [NSString stringWithFormat:@"-> %@ ", object_getClass(_object)];
+  return [NSString stringWithFormat:@"-> %@ ", [self classNameOrNull]];
 }
 
 - (size_t)objectAddress
@@ -114,7 +114,7 @@
 
 - (NSString *)classNameOrNull
 {
-  NSString *className = NSStringFromClass(object_getClass(_object));
+  NSString *className = NSStringFromClass([self objectClass]);
   if (!className) {
     className = @"Null";
   }

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongRelationDetector.h
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongRelationDetector.h
@@ -36,4 +36,6 @@ struct _block_byref_block;
 
 - (oneway void)trueRelease;
 
+- (void *)forwarding;
+
 @end

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongRelationDetector.m
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongRelationDetector.m
@@ -47,4 +47,9 @@ static void byref_dispose_nop(struct _block_byref_block *param) {}
   [super release];
 }
 
+- (void *)forwarding
+{
+  return self->forwarding;
+}
+
 @end


### PR DESCRIPTION
In order to better track the source of some cycles which involve blocks, we need to de-anonymize them and transform them from `MallocBlock` to a form helping track the code involved.

This can be done using the `(void*)invoke` pointer in the block object.

This change introduces an optional feature that adds the instruction pointer to the block of code.
Example:

```
// Before this change.
__MallocBlock__

// After this change.
<<__MallocBlock__:0xADDR>>

// After symbolicating this address on some backend services.
___88-[Classname method:param:]_block_invoke
```

Tested locally by creating an arbitrary leak in a class, which after manual symbolication resulted in something like:

```
___88-[Classname method:param:]_block_invoke
```

Note that because of the use of ASLR on iOS, the pointer of the block's code is changing at each run, to be able to symbolicate this pointer, you'll want to dump the address at which each library is loaded in memory and compare that with your debug binary. This will give you the address of the symbol relative to the debug binary and allow you to extract it using, for example, `nm`.

Check out this page for more details of the ABI of blocks: https://clang.llvm.org/docs/Block-ABI-Apple.html#high-level