### PR TITLE
Remove dead cycles

### DIFF
--- a/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
+++ b/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
@@ -69,6 +69,21 @@ static const NSUInteger kFBRetainCycleDetectorDefaultStackDepth = 10;
   [_candidates removeAllObjects];
   [_objectSet removeAllObjects];
 
+  // Filter cycles that have been broken down since we found them.
+  // These are false-positive that were picked-up and are transient cycles.
+  NSMutableSet<NSArray<FBObjectiveCGraphElement *> *> *remove = [NSMutableSet set];
+  for (NSArray<FBObjectiveCGraphElement *> *itemCycle in allRetainCycles) {
+    for (FBObjectiveCGraphElement *element in itemCycle) {
+      if (element.object == nil) {
+        // At least one element of the cycle has been removed, thuse breaking
+        // the cycle.
+        [remove addObject:itemCycle];
+        break;
+      }
+    }
+  }
+  [allRetainCycles minusSet:remove];
+
   return allRetainCycles;
 }
 

--- a/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
+++ b/FBRetainCycleDetector/Detector/FBRetainCycleDetector.mm
@@ -71,18 +71,18 @@ static const NSUInteger kFBRetainCycleDetectorDefaultStackDepth = 10;
 
   // Filter cycles that have been broken down since we found them.
   // These are false-positive that were picked-up and are transient cycles.
-  NSMutableSet<NSArray<FBObjectiveCGraphElement *> *> *remove = [NSMutableSet set];
+  NSMutableSet<NSArray<FBObjectiveCGraphElement *> *> *brokenCycles = [NSMutableSet set];
   for (NSArray<FBObjectiveCGraphElement *> *itemCycle in allRetainCycles) {
     for (FBObjectiveCGraphElement *element in itemCycle) {
       if (element.object == nil) {
-        // At least one element of the cycle has been removed, thuse breaking
+        // At least one element of the cycle has been removed, thus breaking
         // the cycle.
-        [remove addObject:itemCycle];
+        [brokenCycles addObject:itemCycle];
         break;
       }
     }
   }
-  [allRetainCycles minusSet:remove];
+  [allRetainCycles minusSet:brokenCycles];
 
   return allRetainCycles;
 }

--- a/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCBlock.m
@@ -72,7 +72,7 @@ struct __attribute__((packed)) BlockLiteral {
 {
   NSString *className = NSStringFromClass([self objectClass]);
   if (!className) {
-    className = @"Null";
+    className = @"(null)";
   }
 
   if (!self.configuration.shouldIncludeBlockAddress) {

--- a/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.mm
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCGraphElement.mm
@@ -116,7 +116,7 @@
 {
   NSString *className = NSStringFromClass([self objectClass]);
   if (!className) {
-    className = @"Null";
+    className = @"(null)";
   }
 
   return className;


### PR DESCRIPTION
Some cycles that are temporary and broken down manually will be picked up by RetainCycleDetector. They will be reported even though there is no reason to. Even more the report will contain cryptic "(null)" that are not actionable.

This change will ignore such cycle at the source which should reduce the number of "bad" reports to filter later down and decrease data usage as a result.

The objects will also be reported as "(null)" rather than "Null" for the sake of consistency.

Based of @without2002's work https://github.com/facebook/FBRetainCycleDetector/pull/25
Since the pull request is very old and the author likely have moved on, although the change is a good idea, I'll merge is here with minor changes for speed.