### PR TITLE
Solve FBRetainCycleDetector.podspec.json change

### DIFF
--- a/FBRetainCycleDetector.podspec
+++ b/FBRetainCycleDetector.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   files = files.map {|file| file.to_path}
   files = files.reject {|file| mrr_files.include?(file)}
 
-  s.requires_arc = files + [
+  s.requires_arc = files.sort + [
     'fishhook/**/*.{c,h}'
   ]
   s.public_header_files = [


### PR DESCRIPTION
Solve the FBRetainCycleDetector.podspec.json sometimes change the problem
when use cocoapods ,that will produce `FBRetainCycleDetector.podspec.json`, sometimes change