### PR TITLE
Update fishhook with nullptr dereference fix

### DIFF
--- a/rcd_fishhook/rcd_fishhook.c
+++ b/rcd_fishhook/rcd_fishhook.c
@@ -186,7 +186,7 @@ int rcd_rebind_symbols_image(void *header,
     struct rcd_rebindings_entry *rebindings_head = NULL;
     int retval = rcd_prepend_rebindings(&rebindings_head, rebindings, rebindings_nel);
     rebind_symbols_for_image(rebindings_head, (const struct mach_header *) header, slide);
-    if (rebindings_head->rebindings) {
+    if (rebindings_head) {
       free(rebindings_head->rebindings);
     }
     free(rebindings_head);

--- a/update_fishhook.sh
+++ b/update_fishhook.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -x
+set -e
+
+cd -- "$(dirname -- "$0")"
+
+# Download data in temp dir.
+rcd_fishhook_path="$(pwd)/rcd_fishhook/"
+git_fishhook_path=$(mktemp -d /tmp/rcd-fishhook.XXXXXX)
+if [ $? -ne 0 ]; then
+    echo "$0: Can't create temp file, exiting..."
+    exit 1
+fi
+cd -- "$git_fishhook_path"
+git clone 'git@github.com:facebook/fishhook.git'
+
+# Update repo.
+cd "${rcd_fishhook_path}"
+rm -- rcd_fishhook.* || true
+cp -r "${git_fishhook_path}"/fishhook/* .
+rm fishhook.podspec
+
+sed -i '' 's/fishhook_h/rcd_fishhook_h/g' fishhook.*
+sed -i '' 's/fishhook\.h/rcd_fishhook\.h/g' fishhook.*
+sed -i '' 's/struct rebinding/struct rcd_rebinding/g' fishhook.*
+sed -E -i '' 's/(rebind_symbols(_image)?|prepend_rebindings|perform_rebinding_with_section)\(/rcd_\1\(/g' fishhook.*
+
+mv fishhook.h rcd_fishhook.h
+mv fishhook.c rcd_fishhook.c
+
+# Clean up.
+rm -rf "$git_fishhook"


### PR DESCRIPTION
Simple fix synched for fishhook, I'm also committing the script I'm using to update the fishhook code from the other repo. This is not a very good practice to use dependency like that, I'm welcoming merges to fix it but in the mean time it's better than the status quo.