### PR TITLE
Add null check before dereferencing c string pointer

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/Reference/FBIvarReference.m
+++ b/FBRetainCycleDetector/Layout/Classes/Reference/FBIvarReference.m
@@ -26,6 +26,10 @@
 
 - (FBType)_convertEncodingToType:(const char *)typeEncoding
 {
+  if (typeEncoding == NULL) {
+    return FBUnknownType;
+  }
+
   if (typeEncoding[0] == '{') {
     return FBStructType;
   }


### PR DESCRIPTION
Fixes issue 72.

A null c string pointer is dereferenced before a null check, so let's add a null check. A deeper dive should be undertaken to understand in what conditions other than a null ivar, `ivar_getTypeEncoding` returns null.