### PR TITLE
Fix a crash issue when meeting up NSMapTable with NSPointerFunctionsOpaqueMemory.

### DIFF
--- a/FBRetainCycleDetector/Graph/FBObjectiveCObject.m
+++ b/FBRetainCycleDetector/Graph/FBObjectiveCObject.m
@@ -113,6 +113,9 @@
 {
   if ([self.object respondsToSelector:@selector(valuePointerFunctions)]) {
     NSPointerFunctions *pointerFunctions = [self.object valuePointerFunctions];
+    if (pointerFunctions.acquireFunction == NULL) {
+      return NO;
+    }
     if (pointerFunctions.usesWeakReadAndWriteBarriers) {
       return NO;
     }
@@ -128,6 +131,9 @@
     // If object shows what pointer functions are used, lets try to determine
     // if it's not retaining objects
     NSPointerFunctions *pointerFunctions = [self.object pointerFunctions];
+    if (pointerFunctions.acquireFunction == NULL) {
+      return NO;
+    }
     if (pointerFunctions.usesWeakReadAndWriteBarriers) {
       // It's weak - we should not touch it
       return NO;
@@ -136,6 +142,9 @@
 
   if ([self.object respondsToSelector:@selector(keyPointerFunctions)]) {
     NSPointerFunctions *pointerFunctions = [self.object keyPointerFunctions];
+    if (pointerFunctions.acquireFunction == NULL) {
+      return NO;
+    }
     if (pointerFunctions.usesWeakReadAndWriteBarriers) {
       return NO;
     }

--- a/FBRetainCycleDetectorTests/FBRCDCollectionTests.m
+++ b/FBRetainCycleDetectorTests/FBRCDCollectionTests.m
@@ -91,6 +91,18 @@
   XCTAssertFalse([retainCycles containsObject:[[FBObjectiveCObject alloc] initWithObject:testCollection]]);
 }
 
+- (void)testNSMapTableWithOpaqueMemoryOption {
+  NSMapTable *mapTableWithOpaqueMemory = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsIntegerPersonality valueOptions:NSPointerFunctionsOpaqueMemory | NSPointerFunctionsIntegerPersonality capacity:0];
+  NSInteger sample = 1;
+  [mapTableWithOpaqueMemory setObject:(__bridge id)((void *)sample) forKey:(__bridge id)((void *)sample)];
+  
+  FBRetainCycleDetector *detector = [FBRetainCycleDetector new];
+  [detector addCandidate:mapTableWithOpaqueMemory];
+  NSSet *retainCycles = [detector findRetainCycles];
+  
+  XCTAssertFalse([retainCycles containsObject:[[FBObjectiveCObject alloc] initWithObject:mapTableWithOpaqueMemory]]);
+}
+
 #endif //_INTERNAL_RCD_ENABLED
 
 @end


### PR DESCRIPTION
Fix a crash issue when meeting up NSMapTable with NSPointerFunctionsOpaqueMemory.

https://github.com/facebook/FBRetainCycleDetector/issues/60#issuecomment-503511056

For `NSMapTable` with `NSPointerFunctionsOpaqueMemory`, FBRetainCycleDetector treats inner object as strong reference, as `pointerFunctions.usesWeakReadAndWriteBarriers` returns NO.

`acquireFunction` is called for copy-in operations. If `acquireFunction` is NULL, it means nothing will be done when copied-in, so the memory will not be retained. 
It cannot be guarantee that `acquireFunction` is always NULL when the memory option is NSPointerFunctionsOpaqueMemory. But it is better than we do nothing.

The crash can be reproduced in the added test case. 