### PR TITLE
Build with Xcode 11

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/Parser/Struct.h
+++ b/FBRetainCycleDetector/Layout/Classes/Parser/Struct.h
@@ -19,7 +19,7 @@ namespace FB { namespace RetainCycleDetector { namespace Parser {
   class Struct: public Type {
   public:
     const std::string structTypeName;
-    
+
     Struct(const std::string &name,
            const std::string &typeEncoding,
            const std::string &structTypeName,
@@ -28,13 +28,12 @@ namespace FB { namespace RetainCycleDetector { namespace Parser {
       structTypeName(structTypeName),
     typesContainedInStruct(std::move(typesContainedInStruct)) {};
     Struct(Struct&&) = default;
-    Struct &operator=(Struct&&) = default;
-    
+
     Struct(const Struct&) = delete;
     Struct &operator=(const Struct&) = delete;
-    
+
     std::vector<std::shared_ptr<Type>> flattenTypes();
-    
+
     virtual void passTypePath(std::vector<std::string> typePath);
     std::vector<std::shared_ptr<Type>> typesContainedInStruct;
   };

--- a/FBRetainCycleDetector/Layout/Classes/Parser/Type.h
+++ b/FBRetainCycleDetector/Layout/Classes/Parser/Type.h
@@ -20,19 +20,18 @@ namespace FB { namespace RetainCycleDetector { namespace Parser {
   public:
     const std::string name;
     const std::string typeEncoding;
-    
+
     Type(const std::string &name,
          const std::string &typeEncoding): name(name), typeEncoding(typeEncoding) {}
     Type(Type&&) = default;
-    Type &operator=(Type&&) = default;
-    
+
     Type(const Type&) = delete;
     Type &operator=(const Type&) = delete;
-    
+
     virtual void passTypePath(std::vector<std::string> typePath) {
       this->typePath = typePath;
     }
-    
+
     std::vector<std::string> typePath;
   };
 } } }


### PR DESCRIPTION
These files were being flagged by the `-Wdefaulted-function-deleted`
flag.

```
FBRetainCycleDetector/Layout/Classes/Parser/Struct.h:31:13: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
FBRetainCycleDetector/Layout/Classes/Parser/Type.h:27:11: error: explicitly defaulted move assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
```

As these are implicitly deleted, just go ahead and delete them.