### PR TITLE
Properly restore protections for iOS 13

### DIFF
--- a/rcd_fishhook/rcd_fishhook.c
+++ b/rcd_fishhook/rcd_fishhook.c
@@ -29,6 +29,9 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/types.h>
+#include <mach/mach.h>
+#include <mach/vm_map.h>
+#include <mach/vm_region.h>
 #include <mach-o/dyld.h>
 #include <mach-o/loader.h>
 #include <mach-o/nlist.h>
@@ -78,6 +81,27 @@ static int rcd_prepend_rebindings(struct rcd_rebindings_entry **rebindings_head,
   return 0;
 }
 
+static vm_prot_t get_protection(void *sectionStart) {
+  mach_port_t task = mach_task_self();
+  vm_size_t size = 0;
+  vm_address_t address = (vm_address_t)sectionStart;
+  memory_object_name_t object;
+#if __LP64__
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+  vm_region_basic_info_data_64_t info;
+  kern_return_t info_ret = vm_region_64(
+      task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
+#else
+  mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
+  vm_region_basic_info_data_t info;
+  kern_return_t info_ret = vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
+#endif
+  if (info_ret == KERN_SUCCESS) {
+    return info.protection;
+  } else {
+    return VM_PROT_READ;
+  }
+}
 static void rcd_perform_rebinding_with_section(struct rcd_rebindings_entry *rebindings,
                                            section_t *section,
                                            intptr_t slide,
@@ -87,7 +111,9 @@ static void rcd_perform_rebinding_with_section(struct rcd_rebindings_entry *rebi
   const bool isDataConst = strcmp(section->segname, "__DATA_CONST") == 0;
   uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
   void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
+  vm_prot_t oldProtection = VM_PROT_READ;
   if (isDataConst) {
+    oldProtection = get_protection(rebindings);
     mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
   }
   for (uint i = 0; i < section->size / sizeof(void *); i++) {
@@ -117,7 +143,17 @@ static void rcd_perform_rebinding_with_section(struct rcd_rebindings_entry *rebi
   symbol_loop:;
   }
   if (isDataConst) {
-    mprotect(indirect_symbol_bindings, section->size, PROT_READ);
+    int protection = 0;
+    if (oldProtection & VM_PROT_READ) {
+      protection |= PROT_READ;
+    }
+    if (oldProtection & VM_PROT_WRITE) {
+      protection |= PROT_WRITE;
+    }
+    if (oldProtection & VM_PROT_EXECUTE) {
+      protection |= PROT_EXEC;
+    }
+    mprotect(indirect_symbol_bindings, section->size, protection);
   }
 }
 


### PR DESCRIPTION
The original protection may have been read/write, not just read-only.
Read it & restore it.

Syncing with https://github.com/facebook/fishhook/pull/66