### PR TITLE
Use a simpler way to get strong references in closure.

### DIFF
--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
@@ -19,6 +19,7 @@ enum { // Flags from BlockLiteral
   BLOCK_IS_GLOBAL =         (1 << 28),
   BLOCK_HAS_STRET =         (1 << 29), // IFF BLOCK_HAS_SIGNATURE
   BLOCK_HAS_SIGNATURE =     (1 << 30),
+  BLOCK_HAS_EXTENDED_LAYOUT=(1 << 31)  // compiler
 };
 
 struct BlockDescriptor {
@@ -28,6 +29,7 @@ struct BlockDescriptor {
   void (*copy_helper)(void *dst, void *src); // IFF (1<<25)
   void (*dispose_helper)(void *src);         // IFF (1<<25)
   const char *signature;                     // IFF (1<<30)
+  const char *layout;                        // IFF (1<<31)
 };
 
 struct BlockLiteral {


### PR DESCRIPTION
The idea of ​​the new way comes from the comments in [https://opensource.apple.com/source/libclosure/](libclosure).

`// Extended layout encoding.

// Values for Block_descriptor_3->layout with BLOCK_HAS_EXTENDED_LAYOUT
// and for Block_byref_3->layout with BLOCK_BYREF_LAYOUT_EXTENDED

// If the layout field is less than 0x1000, then it is a compact encoding 
// of the form 0xXYZ: X strong pointers, then Y byref pointers, 
// then Z weak pointers.

// If the layout field is 0x1000 or greater, it points to a 
// string of layout bytes. Each byte is of the form 0xPN.
// Operator P is from the list below. Value N is a parameter for the operator.
// Byte 0x00 terminates the layout; remaining block data is non-pointer bytes.
`