### PR TITLE
Use a simpler way to get strong references of block.

### DIFF
--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
@@ -22,6 +22,25 @@ enum { // Flags from BlockLiteral
   BLOCK_HAS_EXTENDED_LAYOUT=(1 << 31)  // compiler
 };
 
+enum {
+    BLOCK_LAYOUT_ESCAPE = 0, // N=0 halt, rest is non-pointer. N!=0 reserved.
+    BLOCK_LAYOUT_NON_OBJECT_BYTES = 1,    // N bytes non-objects
+    BLOCK_LAYOUT_NON_OBJECT_WORDS = 2,    // N words non-objects
+    BLOCK_LAYOUT_STRONG           = 3,    // N words strong pointers
+    BLOCK_LAYOUT_BYREF            = 4,    // N words byref pointers
+    BLOCK_LAYOUT_WEAK             = 5,    // N words weak pointers
+    BLOCK_LAYOUT_UNRETAINED       = 6,    // N words unretained pointers
+    BLOCK_LAYOUT_UNKNOWN_WORDS_7  = 7,    // N words, reserved
+    BLOCK_LAYOUT_UNKNOWN_WORDS_8  = 8,    // N words, reserved
+    BLOCK_LAYOUT_UNKNOWN_WORDS_9  = 9,    // N words, reserved
+    BLOCK_LAYOUT_UNKNOWN_WORDS_A  = 0xA,  // N words, reserved
+    BLOCK_LAYOUT_UNUSED_B         = 0xB,  // unspecified, reserved
+    BLOCK_LAYOUT_UNUSED_C         = 0xC,  // unspecified, reserved
+    BLOCK_LAYOUT_UNUSED_D         = 0xD,  // unspecified, reserved
+    BLOCK_LAYOUT_UNUSED_E         = 0xE,  // unspecified, reserved
+    BLOCK_LAYOUT_UNUSED_F         = 0xF,  // unspecified, reserved
+};
+
 struct BlockDescriptor {
   unsigned long int reserved;                // NULL
   unsigned long int size;

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
@@ -41,6 +41,25 @@ enum {
     BLOCK_LAYOUT_UNUSED_F         = 0xF,  // unspecified, reserved
 };
 
+// Values for Block_byref->flags to describe __block variables
+enum {
+    // Byref refcount must use the same bits as Block_layout's refcount.
+    // BLOCK_DEALLOCATING =      (0x0001),  // runtime
+    // BLOCK_REFCOUNT_MASK =     (0xfffe),  // runtime
+
+    BLOCK_BYREF_LAYOUT_MASK =       (0xf << 28), // compiler
+    BLOCK_BYREF_LAYOUT_EXTENDED =   (  1 << 28), // compiler
+    BLOCK_BYREF_LAYOUT_NON_OBJECT = (  2 << 28), // compiler
+    BLOCK_BYREF_LAYOUT_STRONG =     (  3 << 28), // compiler
+    BLOCK_BYREF_LAYOUT_WEAK =       (  4 << 28), // compiler
+    BLOCK_BYREF_LAYOUT_UNRETAINED = (  5 << 28), // compiler
+
+    BLOCK_BYREF_IS_GC =             (  1 << 27), // runtime
+
+    BLOCK_BYREF_HAS_COPY_DISPOSE =  (  1 << 25), // compiler
+    BLOCK_BYREF_NEEDS_FREE =        (  1 << 24), // runtime
+};
+
 struct BlockDescriptor {
   unsigned long int reserved;                // NULL
   unsigned long int size;
@@ -58,4 +77,13 @@ struct BlockLiteral {
   void (*invoke)(void *, ...);
   struct BlockDescriptor *descriptor;
   // imported variables
+};
+
+struct Block_byref {
+    void *isa;
+    struct Block_byref *forwarding;
+    volatile int32_t flags; // contains ref count
+    uint32_t size;
+    void (*keep_helper)(void *dst, void *src);
+    void (*destory_helper)(void *src);
 };

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockInterface.h
@@ -19,6 +19,7 @@ enum { // Flags from BlockLiteral
   BLOCK_IS_GLOBAL =         (1 << 28),
   BLOCK_HAS_STRET =         (1 << 29), // IFF BLOCK_HAS_SIGNATURE
   BLOCK_HAS_SIGNATURE =     (1 << 30),
+  BLOCK_HAS_EXTENDED_LAYOUT=(1 << 31)  // compiler
 };
 
 struct BlockDescriptor {
@@ -28,6 +29,7 @@ struct BlockDescriptor {
   void (*copy_helper)(void *dst, void *src); // IFF (1<<25)
   void (*dispose_helper)(void *src);         // IFF (1<<25)
   const char *signature;                     // IFF (1<<30)
+  const char *layout;                        // IFF (1<<31)
 };
 
 struct BlockLiteral {

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
@@ -108,9 +108,9 @@ NSArray *FBGetBlockStrongReferences(void *block) {
         for (int i = 0; layout[i] != '\0'; i++) {
             int p = (layout[i] & 0xF0) >> 4;
             if (p == BLOCK_LAYOUT_STRONG) {
-                strongReferenceCount = (layout[i] & 0x0F) + 1;
+                strongReferenceCount += (layout[i] & 0x0F) + 1;
             } else if (p == BLOCK_LAYOUT_BYREF) {
-                byrefReferenceCount = (layout[i] & 0x0F) + 1;
+                byrefReferenceCount += (layout[i] & 0x0F) + 1;
             }
         }
     }

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
@@ -127,7 +127,7 @@ NSArray *FBGetBlockStrongReferences(void *block) {
     if (byrefReferenceCount) {
         for (int i = 0; i < byrefReferenceCount; i++, desc += sizeof(void *)) {
             struct Block_byref *blockByref = (struct Block_byref *)(*((void **)desc));
-            if (blockByref->flags && BLOCK_BYREF_HAS_COPY_DISPOSE) {
+            if ((blockByref->flags & BLOCK_BYREF_HAS_COPY_DISPOSE) && (blockByref->flags & BLOCK_BYREF_LAYOUT_STRONG)) {
                 void *byrefDesc = (uint8_t *)blockByref + sizeof(*blockByref);
                 id strongRef = (__bridge id)(*((void **)byrefDesc));
                 if (strongRef) [results addObject:strongRef];

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
@@ -77,27 +77,28 @@ static NSIndexSet *_GetBlockStrongLayout(void *block) {
 }
 
 NSArray *FBGetBlockStrongReferences(void *block) {
-  if (!FBObjectIsBlock(block)) {
-    return nil;
-  }
-  
-  NSMutableArray *results = [NSMutableArray new];
-
-  void **blockReference = block;
-  NSIndexSet *strongLayout = _GetBlockStrongLayout(block);
-  [strongLayout enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
-    void **reference = &blockReference[idx];
-
-    if (reference && (*reference)) {
-      id object = (id)(*reference);
-
-      if (object) {
-        [results addObject:object];
-      }
+    if (!FBObjectIsBlock(block)) {
+      return nil;
     }
-  }];
 
-  return [results autorelease];
+    NSMutableArray *results = [NSMutableArray new];
+
+    struct BlockLiteral *blockLiteral = block;
+
+    if (!(blockLiteral->flags & BLOCK_HAS_EXTENDED_LAYOUT) ||
+        !(blockLiteral->flags & BLOCK_HAS_COPY_DISPOSE) ||
+        !(blockLiteral->flags & BLOCK_HAS_SIGNATURE)) return results;
+
+    int strongReferenceCount = ((int)blockLiteral->descriptor->layout & 0xF00) >> 8;
+    if (!strongReferenceCount) return results;
+
+    void *desc = (uint8_t *)block + sizeof(*blockLiteral);
+    for (int i = 0; i < strongReferenceCount; i++, desc += sizeof(void *)) {
+        id strongRef = (__bridge id)(*((void **)desc));
+        [results addObject:strongRef];
+    }
+
+    return results;
 }
 
 static Class _BlockClass() {

--- a/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
+++ b/FBRetainCycleDetector/Layout/Blocks/FBBlockStrongLayout.m
@@ -105,7 +105,7 @@ NSArray *FBGetBlockStrongReferences(void *block) {
         strongReferenceCount = ((int)layout & 0xF00) >> 8;
         byrefReferenceCount = ((int)layout & 0x0F0) >> 4;
     } else {
-        for (int i = 0; layout[i] != '\0'; i++) {
+        for (int i = 0; layout[i] != 0x00; i++) {
             int p = (layout[i] & 0xF0) >> 4;
             if (p == BLOCK_LAYOUT_STRONG) {
                 strongReferenceCount += (layout[i] & 0x0F) + 1;

--- a/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
+++ b/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
@@ -129,7 +129,6 @@
     NSArray *retainedObjects = FBGetBlockStrongReferences((__bridge void *)(block));
     XCTAssertEqual([retainedObjects count], 15);
 
-#define assertObject(A) XCTAssertEqualObjects(retainedObjects[A], object##A);
     assertObject(0); assertObject(1); assertObject(2); assertObject(3);
     assertObject(4); assertObject(5); assertObject(6); assertObject(7);
     assertObject(8); assertObject(9); assertObject(10); assertObject(11);

--- a/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
+++ b/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
@@ -104,15 +104,21 @@
   XCTAssertEqual([retainedObjects count], 0);
 }
 
+#define newObject(A) NSObject *object##A = [NSObject new]
+#define __blockNewObject(A) __block NSObject *object##A = [NSObject new]
+#define useObject(A) __unused NSObject *someObject##A = object##A
+#define assertObject(A) XCTAssertEqualObjects(retainedObjects[A], object##A);
+
 - (void)testBlockRetains15StrongReferences
 {
-#define newObject(A) NSObject *object##A = [NSObject new]
+
     newObject(0); newObject(1); newObject(2); newObject(3);
     newObject(4); newObject(5); newObject(6); newObject(7);
-    newObject(8); newObject(9); newObject(10); newObject(11);
-    newObject(12); newObject(13); newObject(14);
+    
+    __blockNewObject(8); __blockNewObject(9); __blockNewObject(10); __blockNewObject(11);
+    __blockNewObject(12); __blockNewObject(13); __blockNewObject(14);
 
-#define useObject(A) __unused NSObject *someObject##A = object##A
+
     void (^block)() = ^{
         useObject(0); useObject(1); useObject(2); useObject(3);
         useObject(4); useObject(5); useObject(6); useObject(7);
@@ -132,13 +138,12 @@
 
 - (void)testBlockRetainsMoreThan15StrongReferences
 {
-#define newObject(A) NSObject *object##A = [NSObject new]
     newObject(0); newObject(1); newObject(2); newObject(3);
     newObject(4); newObject(5); newObject(6); newObject(7);
-    newObject(8); newObject(9); newObject(10); newObject(11);
-    newObject(12); newObject(13); newObject(14); newObject(15);
+    
+    __blockNewObject(8); __blockNewObject(9); __blockNewObject(10); __blockNewObject(11);
+    __blockNewObject(12); __blockNewObject(13); __blockNewObject(14); __blockNewObject(15);
 
-#define useObject(A) __unused NSObject *someObject##A = object##A
     void (^block)() = ^{
         useObject(0); useObject(1); useObject(2); useObject(3);
         useObject(4); useObject(5); useObject(6); useObject(7);
@@ -148,8 +153,6 @@
 
     NSArray *retainedObjects = FBGetBlockStrongReferences((__bridge void *)(block));
     XCTAssertEqual([retainedObjects count], 16);
-
-#define assertObject(A) XCTAssertEqualObjects(retainedObjects[A], object##A);
 
     assertObject(0); assertObject(1); assertObject(2); assertObject(3);
     assertObject(4); assertObject(5); assertObject(6); assertObject(7);

--- a/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
+++ b/FBRetainCycleDetectorTests/FBBlockStrongLayoutTests.mm
@@ -104,4 +104,57 @@
   XCTAssertEqual([retainedObjects count], 0);
 }
 
+- (void)testBlockRetains15StrongReferences
+{
+#define newObject(A) NSObject *object##A = [NSObject new]
+    newObject(0); newObject(1); newObject(2); newObject(3);
+    newObject(4); newObject(5); newObject(6); newObject(7);
+    newObject(8); newObject(9); newObject(10); newObject(11);
+    newObject(12); newObject(13); newObject(14);
+
+#define useObject(A) __unused NSObject *someObject##A = object##A
+    void (^block)() = ^{
+        useObject(0); useObject(1); useObject(2); useObject(3);
+        useObject(4); useObject(5); useObject(6); useObject(7);
+        useObject(8); useObject(9); useObject(10); useObject(11);
+        useObject(12); useObject(13); useObject(14);
+    };
+
+    NSArray *retainedObjects = FBGetBlockStrongReferences((__bridge void *)(block));
+    XCTAssertEqual([retainedObjects count], 15);
+
+#define assertObject(A) XCTAssertEqualObjects(retainedObjects[A], object##A);
+    assertObject(0); assertObject(1); assertObject(2); assertObject(3);
+    assertObject(4); assertObject(5); assertObject(6); assertObject(7);
+    assertObject(8); assertObject(9); assertObject(10); assertObject(11);
+    assertObject(12); assertObject(13); assertObject(14);
+}
+
+- (void)testBlockRetainsMoreThan15StrongReferences
+{
+#define newObject(A) NSObject *object##A = [NSObject new]
+    newObject(0); newObject(1); newObject(2); newObject(3);
+    newObject(4); newObject(5); newObject(6); newObject(7);
+    newObject(8); newObject(9); newObject(10); newObject(11);
+    newObject(12); newObject(13); newObject(14); newObject(15);
+
+#define useObject(A) __unused NSObject *someObject##A = object##A
+    void (^block)() = ^{
+        useObject(0); useObject(1); useObject(2); useObject(3);
+        useObject(4); useObject(5); useObject(6); useObject(7);
+        useObject(8); useObject(9); useObject(10); useObject(11);
+        useObject(12); useObject(13); useObject(14); useObject(15);
+    };
+
+    NSArray *retainedObjects = FBGetBlockStrongReferences((__bridge void *)(block));
+    XCTAssertEqual([retainedObjects count], 16);
+
+#define assertObject(A) XCTAssertEqualObjects(retainedObjects[A], object##A);
+
+    assertObject(0); assertObject(1); assertObject(2); assertObject(3);
+    assertObject(4); assertObject(5); assertObject(6); assertObject(7);
+    assertObject(8); assertObject(9); assertObject(10); assertObject(11);
+    assertObject(12); assertObject(13); assertObject(14); assertObject(15);
+}
+
 @end

--- a/FBRetainCycleDetectorTests/FBRetainCycleDetectorTests.mm
+++ b/FBRetainCycleDetectorTests/FBRetainCycleDetectorTests.mm
@@ -772,6 +772,27 @@ typedef struct {
   XCTAssertEqualObjects(retainCycles, expectedSet);
 }
 
+
+- (void)testThatDetectorWillFindCycleUsingBlockType
+{
+    _RCDTestClass *testObject = [_RCDTestClass new];
+    __block typeof(testObject) bt = testObject;
+    _RCDTestBlockType block = ^{
+        [bt description];
+    };
+    testObject.block = [block copy];
+    
+    FBRetainCycleDetector *detector = [FBRetainCycleDetector new];
+    [detector addCandidate:testObject];
+    NSSet *retainCycles = [detector findRetainCycles];
+    
+    NSSet *expectedSet = [NSSet setWithObject:[detector _shiftToUnifiedCycle:
+                                               @[[[FBObjectiveCObject alloc] initWithObject:testObject],
+                                                 [[FBObjectiveCBlock alloc] initWithObject:block]]]];
+    
+    XCTAssertEqualObjects(retainCycles, expectedSet);
+}
+
 #endif //_INTERNAL_RCD_ENABLED
 
 @end


### PR DESCRIPTION
Inspired by [libclosure](https://opensource.apple.com/source/libclosure/).

```
// Extended layout encoding.

// Values for Block_descriptor_3->layout with BLOCK_HAS_EXTENDED_LAYOUT
// and for Block_byref_3->layout with BLOCK_BYREF_LAYOUT_EXTENDED

// If the layout field is less than 0x1000, then it is a compact encoding 
// of the form 0xXYZ: X strong pointers, then Y byref pointers, 
// then Z weak pointers.

// If the layout field is 0x1000 or greater, it points to a 
// string of layout bytes. Each byte is of the form 0xPN.
// Operator P is from the list below. Value N is a parameter for the operator.
// Byte 0x00 terminates the layout; remaining block data is non-pointer bytes.
```