### PR TITLE
Fix wrong strong layout result because of unaligned instance start.

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
+++ b/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
@@ -146,7 +146,8 @@ static NSUInteger FBGetMinimumIvarIndex(__unsafe_unretained Class aCls) {
   if (count > 0) {
     Ivar ivar = ivars[0];
     ptrdiff_t offset = ivar_getOffset(ivar);
-    minimumIndex = offset / (sizeof(void *));
+    // unaligned bytes at the start of this class's ivars are not represented in the layout bitmap.
+    minimumIndex = (offset + (sizeof(void *) - 1)) / (sizeof(void *));
   }
 
   free(ivars);

--- a/FBRetainCycleDetectorTests/FBClassStrongLayoutTests.mm
+++ b/FBRetainCycleDetectorTests/FBClassStrongLayoutTests.mm
@@ -13,6 +13,7 @@
 
 #import <FBRetainCycleDetector/FBClassStrongLayout.h>
 #import <FBRetainCycleDetector/FBRetainCycleDetector.h>
+#import <FBRetainCycleDetector/FBObjectReference.h>
 
 @interface _RCDTestEmptyClass : NSObject
 @end
@@ -157,6 +158,22 @@ typedef struct {
 }
 @end
 
+@interface _RCDTestClassWithUnalignEndIvar : NSObject {
+  char content[20];
+}
+@end
+@implementation _RCDTestClassWithUnalignEndIvar
+@end
+
+@interface _RCDTestClassWithUnalignEndIvarParentClass : _RCDTestClassWithUnalignEndIvar {
+  int integer;
+  __weak NSObject *object1;
+  NSObject *object2;
+}
+@end
+@implementation _RCDTestClassWithUnalignEndIvarParentClass
+@end
+
 @interface FBClassStrongLayoutTests : XCTestCase
 @end
 
@@ -258,6 +275,13 @@ typedef struct {
   NSArray *ivars = FBGetObjectStrongReferences([_RCDTestClassWithCppStructAndStrongProperty new], nil);
 
   XCTAssertEqual([ivars count], 1);
+}
+
+- (void)testLayoutForClassWithParentClassHasUnalignEndIvar
+{
+  NSArray<id<FBObjectReference>> *ivars = FBGetObjectStrongReferences([_RCDTestClassWithUnalignEndIvarParentClass new], nil);
+  XCTAssertEqual([ivars count], 1);
+  XCTAssertEqualObjects([[ivars firstObject] namePath], @[@"object2"]);
 }
 
 @end


### PR DESCRIPTION
Inspired by:
https://opensource.apple.com/source/objc4/objc4-756.2/runtime/objc-class.mm
void _class_lookUpIvar()