### PR TITLE
recreate ci.yml to add CI via GithubActions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: ./build.sh


### PR DESCRIPTION
looks like old ci.yml isn't working, possibly because of bad directory naming. this one *should* be correct