### PR TITLE
fixed iOS 15 Crash

### DIFF
--- a/rcd_fishhook/rcd_fishhook.c
+++ b/rcd_fishhook/rcd_fishhook.c
@@ -119,7 +119,9 @@ static void rcd_perform_rebinding_with_section(struct rcd_rebindings_entry *rebi
               indirect_symbol_bindings[i] != cur->rebindings[j].replacement) {
             *(cur->rebindings[j].replaced) = indirect_symbol_bindings[i];
           }
-          indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          if (i < (sizeof(indirect_symbol_bindings) / sizeof(indirect_symbol_bindings[0]))) {
+              indirect_symbol_bindings[i] = cur->rebindings[j].replacement;
+          }
           goto symbol_loop;
         }
       }


### PR DESCRIPTION
Provided by https://github.com/facebook/FBRetainCycleDetector/issues/122#issuecomment-924629443