### PR TITLE
Fix Swift introspection when reading inherited properties

### DIFF
--- a/FBRetainCycleDetector/Layout/Classes/SwiftIntrospector.swift
+++ b/FBRetainCycleDetector/Layout/Classes/SwiftIntrospector.swift
@@ -19,17 +19,30 @@ import Foundation
 
     /// Get the value of the property
     @objc public class func getPropertyValue(object:Any, name:String) -> Any? {
-            let mirror = Mirror(reflecting: object)
-            guard let array = AnyBidirectionalCollection(mirror.children) else {
-                return nil
+        let mirror = Mirror(reflecting: object)
+        var currentMirror: Mirror? = mirror
+        while currentMirror != nil {
+            let (value, found) = getChild(mirror: currentMirror!, name: name)
+            if found {
+                return value
+            } else {
+                // Check parent mirror if present
+                currentMirror = currentMirror?.superclassMirror
             }
-
-            for child in array  {
-                if let label = child.label, label == name {
-                    return child.value
-                }
-            }
+        }
         return nil
      }
 
+    private class func getChild(mirror: Mirror, name: String) -> (Any?, Bool) {
+        guard let array = AnyBidirectionalCollection(mirror.children) else {
+            return (nil, false)
+        }
+
+        for child in array {
+            if let label = child.label, label == name {
+                return (child.value, true)
+            }
+        }
+        return (nil, false)
+    }
 }


### PR DESCRIPTION
Fix a bug preventing object references from being detected when the reference is from a property inherited from a parent class.

Example:

```swift

class SomeClass {
   var someReference: AnyObject? = nil
}

class Child: SomeClass {
  init() {}
}

let object = Child()
// This reference will not be inspected successfully
object.someReference = object
```



The logic [here](https://github.com/facebook/FBRetainCycleDetector/blob/3d53bfe535e70963cba3fa4049305023c0dfc3b9/FBRetainCycleDetector/Graph/FBObjectiveCObject.m#L32-L34) would receive a `nil` value for `referencedObject` if the object's `Mirror` did not have a direct child for the associated `Ivar`.

Note: I have tested this manually but the existing project is not in a buildable state in order to be able to write a test.

