### PR TITLE
FIX: "FBRetainCycleDetector/FBRetainCycleDetector-Swift.h" file not found

### DIFF
--- a/FBRetainCycleDetector.podspec
+++ b/FBRetainCycleDetector.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/facebook/FBRetainCycleDetector.git",
     :tag => "0.1.4"
   }
-  s.source_files  = "FBRetainCycleDetector", "{FBRetainCycleDetector,rcd_fishhook}/**/*.{h,m,mm,c}"
+  s.source_files  = "FBRetainCycleDetector", "{FBRetainCycleDetector,rcd_fishhook}/**/*.{h,m,mm,c,swift}"
 
   mrr_files = [
     'FBRetainCycleDetector/Associations/FBAssociationManager.h',
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
     'FBRetainCycleDetector/Layout/Classes/FBClassStrongLayoutHelpers.m',
   ]
 
-  files = Pathname.glob("FBRetainCycleDetector/**/*.{h,m,mm}")
+  files = Pathname.glob("FBRetainCycleDetector/**/*.{h,m,mm,swift}")
   files = files.map {|file| file.to_path}
   files = files.reject {|file| mrr_files.include?(file)}
 

--- a/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
+++ b/FBRetainCycleDetector/Layout/Classes/FBClassStrongLayout.mm
@@ -15,7 +15,7 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#import "FBRetainCycleDetector-Swift.h"
 
 #import "FBIvarReference.h"
 #import "FBObjectInStructReference.h"

--- a/FBRetainCycleDetector/Layout/Classes/Reference/FBSwiftReference.m
+++ b/FBRetainCycleDetector/Layout/Classes/Reference/FBSwiftReference.m
@@ -8,7 +8,7 @@
 
 #import "FBSwiftReference.h"
 
-#import <FBRetainCycleDetector/FBRetainCycleDetector-Swift.h>
+#import "FBRetainCycleDetector-Swift.h"
 
 @implementation FBSwiftReference
 


### PR DESCRIPTION
FIX: "FBRetainCycleDetector/FBRetainCycleDetector-Swift.h file not found" in Xcode 16